### PR TITLE
Fix the base url logic with service_endpoint argument

### DIFF
--- a/src/oci_openai/oci_openai.py
+++ b/src/oci_openai/oci_openai.py
@@ -325,7 +325,7 @@ def _build_service_endpoint(region: str) -> str:
 
 def _build_base_url(service_endpoint: str) -> str:
     url = service_endpoint.rstrip(" /")
-    return f"{url}/openai/v1"
+    return f"{url}/v1"
 
 
 def _resolve_base_url(region: str = None, service_endpoint: str = None, base_url: str = None):


### PR DESCRIPTION
Without this fix, a NotFoundError is thrown when instantiating with service_endpoint argument.

```
client = OciOpenAI(
  service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
  auth=OciUserPrincipalAuth(profile_name="PROFILE_NAME"),
  compartment_id="COMPARTMENT_ID",
)
```

```
Exception has occurred: NotFoundError
Path doesn't map to a registered service!
httpx.HTTPStatusError: Client error '404 Not Found' for url 'https://inference.generativeai.us-chicago-1.oci.oraclecloud.com/openai/v1/chat/completions'
```

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
