### PR TITLE
Fix base_url and compartment id key in ChatCompletions README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,14 +105,12 @@ client = OpenAI(
     base_url="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com/20231130/actions/v1",
     http_client=httpx.Client(
         auth=OciSessionAuth(profile_name="<profile name>"),
-        headers={
-            "CompartmentId": "<compartment ocid>"
-        },
+        headers={"CompartmentId": "<compartment ocid>"}
     ),
 )
 
 completion = client.chat.completions.create(
-    model="openai.gpt-4.1",
+    model="<model name>",
     messages=[
         {
             "role": "user",
@@ -130,18 +128,15 @@ print(completion.model_dump_json())
 from langchain_openai import ChatOpenAI
 import httpx
 from oci_openai import OciUserPrincipalAuth
-import os
 
-
-COMPARTMENT_ID=os.getenv("OCI_COMPARTMENT_ID", "<compartment_id>")
 
 llm = ChatOpenAI(
-    model="<model-name>",  # for example "xai.grok-4-fast-reasoning"
+    model="<model name>",  # for example "xai.grok-4-fast-reasoning"
     api_key="OCI",
     base_url="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com/20231130/actions/v1",
     http_client=httpx.Client(
         auth=OciUserPrincipalAuth(profile_name="<profile name>"),
-        headers={"CompartmentId": COMPARTMENT_ID}
+        headers={"CompartmentId": "<compartment ocid>"}
     ),
     # use_responses_api=True
     # stream_usage=True,


### PR DESCRIPTION
# Description
Some README examples are not working for Generative AI Service ChatCompletions API.

This is because the new path `/openai/v1` and header key `opc-compartment-id` are not accepted by the server yet, as the server deployment was delayed.

This doc fix PR reverts the examples to use legacy base_url path `20231130/actions/v1` and `CompartmentId` header key.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Run the new examples and verify they work


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
